### PR TITLE
Fix syntax for ruby 1.9.3

### DIFF
--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -12,7 +12,7 @@ module ShallowAttributes
     # @private
     #
     # @since 0.1.0
-    TO_H_PROC = -> (value) { value.respond_to?(:to_hash) ? value.to_hash : value }
+    TO_H_PROC = ->(value) { value.respond_to?(:to_hash) ? value.to_hash : value }
 
     # Initialize instance object with specific attributes
     #


### PR DESCRIPTION
It`s fixed syntax error, unexpected tLAMBEG, expecting keyword_end
    TO_H_PROC = -> (value) { value.respond_to?(:to_hash) ..}

I know 1.9.3 is old, but it`s my legacy ;)