### PR TITLE
Remaining `must_equal nil` replaced by `assert_nil`

### DIFF
--- a/test/float_type_test.rb
+++ b/test/float_type_test.rb
@@ -21,7 +21,7 @@ describe ShallowAttributes::Type::Float do
 
     describe 'when value is Nil' do
       it 'returns nil' do
-        type.coerce(nil).must_equal nil
+        assert_nil type.coerce(nil)
       end
     end
 

--- a/test/integer_type_test.rb
+++ b/test/integer_type_test.rb
@@ -20,7 +20,7 @@ describe ShallowAttributes::Type::Integer do
 
     describe 'when value is Nil' do
       it 'returns nil' do
-        type.coerce(nil).must_equal nil
+        assert_nil type.coerce(nil)
       end
     end
 

--- a/test/shallow_attributes_test.rb
+++ b/test/shallow_attributes_test.rb
@@ -37,8 +37,8 @@ describe ShallowAttributes do
     let(:user) { MainUser.new }
 
     it 'builds getters for each attribute' do
-      user.age.must_equal nil
-      user.birthday.must_equal nil
+      assert_nil user.age
+      assert_nil user.birthday
       user.sizes.must_equal []
     end
 


### PR DESCRIPTION
`must_equal' will fail in MT6.