### PR TITLE
Fix inheriting from a base class that does not define any attributes.

### DIFF
--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -6,6 +6,19 @@ module ShallowAttributes
   #
   # @since 0.1.0
   module ClassMethods
+    # Inject our default values into subclasses.
+    #
+    # @private
+    #
+    # @param [Object] subclass
+    #
+    def inherited(subclass)
+      super
+      if respond_to?(:default_values)
+        subclass.default_values.merge!(default_values)
+      end
+    end
+
     # Returns hash which contain default values for each attribute
     #
     # @private
@@ -14,15 +27,10 @@ module ShallowAttributes
     #
     # @since 0.1.0
     def default_values
-      if superclass.respond_to?(:default_values)
-        @default_values.merge!(superclass.default_values) { |_, v, _| v }
-      else
-        @default_values
-      end
+      @default_values ||= {}
     end
 
     # Returns all class attributes.
-    #
     #
     # @example Create new User instance
     #   class User
@@ -66,8 +74,7 @@ module ShallowAttributes
     def attribute(name, type, options = {})
       options[:default] ||= [] if type == Array
 
-      @default_values ||= {}
-      @default_values[name] = options.delete(:default)
+      default_values[name] = options.delete(:default)
 
       initialize_setter(name, type, options)
       initialize_getter(name)

--- a/test/inheritance_test.rb
+++ b/test/inheritance_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# Base class mixes in ShallowAttributes and defines attributes
 class BaseUser
   include ShallowAttributes
 
@@ -20,16 +21,35 @@ class Admin < BaseUser
   attribute :last_name, String
 end
 
+# Base class mixes in ShallowAttributes, but does not define attributes
+class Base1
+  include ShallowAttributes
+end
+
+class Sub1 < Base1
+  attribute :email, String
+end
+
+# Base class does not mix in ShallowAttributes
+class Base2
+end
+
+class Sub2 < Base2
+  include ShallowAttributes
+
+  attribute :email, String
+end
+
 describe ShallowAttributes do
   describe '::attributes' do
     describe 'for inheritance' do
       it 'returns array of all attributes' do
-        Moderator.attributes.must_equal(%i(rates name role))
+        Moderator.attributes.must_equal(%i(name role rates))
       end
     end
   end
 
-  describe 'with inheritance class' do
+  describe 'with inheritance from class that mixes in ShallowAttributes and defines attributes' do
     let(:params) { { name: 'Anton', role: 'moderator', last_name: 'New', rates: [1, 2, 3] } }
     let(:moderator) { Moderator.new(params) }
     let(:admin) { Admin.new(params) }
@@ -68,6 +88,20 @@ describe ShallowAttributes do
       it 'returns last_name attribute correct' do
         admin.last_name.must_equal 'New'
       end
+    end
+  end
+
+  describe 'with inheritance from class that mixes in ShallowAttributes, but does not define attributes' do
+    it 'returns email attribute correct' do
+      search = Sub1.new(email: 'foo@bar.com')
+      search.email.must_equal 'foo@bar.com'
+    end
+  end
+
+  describe 'with inheritance from class that does not mixin ShallowAttributes' do
+    it 'returns email attribute correct' do
+      search = Sub2.new(email: 'foo@bar.com')
+      search.email.must_equal 'foo@bar.com'
     end
   end
 end


### PR DESCRIPTION
Hello,

Firstly, thank you for creating this project 😄. We are using it for our non-ActiveRecord backed forms.

We have a base class that mixes in `ShallowAttributes`, but doesn't define attributes of its own. Any engineer can subclass this base class and have confidence that it will work out of the box in our forms and controllers.

Unfortunately we hit a bug where the subclass would raise `TypeError: no implicit conversion of nil into Hash` because it's trying to read `default_values` from a nil object which it expected to be a hash.

We have managed to work around it by defining `MyExampleBaseClass.default_values` to return an empty hash. While this is satisfactory it means the out of box experience with `ShallowAttributes` is not as smooth as it could be.

I hope you find this patch valuable and I'm open to any feedback you have.

Cheers,
Tate