### PR TITLE
Initializer can take stringified hashes

### DIFF
--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -30,7 +30,11 @@ module ShallowAttributes
     #
     # @since 0.1.0
     def initialize(attrs = {})
-      @attributes = attrs.delete_if { |key, _| !default_values.key?(key) }
+      @attributes = {}
+      attrs.each_pair do |key, value|
+        key = key.to_sym
+        @attributes[key] = value if default_values.key?(key)
+      end
       define_attributes
       define_default_attributes
     end

--- a/test/shallow_attributes_test.rb
+++ b/test/shallow_attributes_test.rb
@@ -50,11 +50,24 @@ describe ShallowAttributes do
       user.age.must_equal 22
     end
 
-    it 'sets attributes from hash' do
+    it 'sets attributes from symbolized hash' do
       user = MainUser.new(name: 'Anton', age: 22)
 
       user.name.must_equal 'Anton'
       user.age.must_equal 22
+    end
+
+    it 'sets attributes from stringified hash' do
+      user = MainUser.new('name' => 'Anton', 'age' => 22)
+
+      user.name.must_equal 'Anton'
+      user.age.must_equal 22
+    end
+
+    it 'does not mutate the argument' do
+      params = {'name' => 'Anton', 'age' => 22}
+      MainUser.new(params)
+      params.must_equal({'name' => 'Anton', 'age' => 22})
     end
 
     it 'sets object as default value for each attribute' do
@@ -87,8 +100,15 @@ describe ShallowAttributes do
   end
 
   describe '#attributes=' do
-    it 'mass-assignments object attributes' do
+    it 'mass-assignments from symbolized hash' do
       user.attributes = { name: 'Alex' }
+
+      user.name.must_equal 'Alex'
+      user.age.must_equal 22
+    end
+
+    it 'mass-assignments from stringified hash' do
+      user.attributes = { 'name' => 'Alex' }
 
       user.name.must_equal 'Alex'
       user.age.must_equal 22


### PR DESCRIPTION
This patch makes `ShallowAttributes` work out of the box with `ActionController::StrongParameters`. The motivations for this patch are:

1. `ShallowAttributes` expects to work with symbolized hashes, but `parameters` in Rails are stringified hashes.
2. The initializer was mutating the hash. When I passed it to another object, it was missing key-value pairs. This tripped me up for a good 10 minutes. 

We were working around **2** by  calling `params.to_h.symbolize_keys` before passing it to the initializer. This made the API feel a little rough and gave me the motivation to write this patch.

You'll notice I used `#each_pair` over `#each_with_object` or `#reduce`. This is the only public method that is available on both `Hash` and `ActionController::StrongParameters` which lets us symbolize the hash.

I'm aware you may be opposed to the patch because it creates a new object and uses `#each_pair`. If you are opposed then I am open to exploring other options to make a great out of the box Rails experience.

Either way let me know. All feedback welcome.

Cheers,
Tate