### PR TITLE
Ruby 2.4.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
+  - 2.4.0
   - jruby-head
   - rbx-2
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -333,10 +333,11 @@ user.valid? # => true
 
 ShallowAttributes is [known to work correctly][travis-link] with the following rubies:
 
-* 2.0.0
-* 2.1.8
-* 2.2.4
-* 2.3.0
+* 2.0
+* 2.1
+* 2.2
+* 2.3
+* 2.4
 * jruby-head
 
 Also we run rbx-2 buld too.


### PR DESCRIPTION
Tests are 💚. Only issue is coveralls depends on simplecov and simplecov is throwing `Fixnum` deprecation warnings. There's a fix in the pipeline at https://github.com/lemurheavy/coveralls-ruby/pull/117. This doesn't affect ShallowAttributes at runtime.

I also removed the patch releases from the ruby versions in the README. They were mismatched against `.travis.yml` and people are really only interested in major and minor versions.

<img width="890" alt="screen shot 2017-03-18 at 9 45 52 am" src="https://cloud.githubusercontent.com/assets/19860/24066659/3914e4b4-0bc0-11e7-8045-57de2e8b82fe.png">
