### PR TITLE
allow use string file name for array elements

### DIFF
--- a/lib/shallow_attributes/type/array.rb
+++ b/lib/shallow_attributes/type/array.rb
@@ -27,8 +27,16 @@ module ShallowAttributes
         unless values.is_a? ::Array
           raise ShallowAttributes::Type::InvalidValueError, %(Invalid value "#{values}" for type "Array")
         end
+        values.map! do |value|
+          ShallowAttributes::Type.coerce(item_klass(options[:of]), value)
+        end
+      end
 
-        values.map! { |value| ShallowAttributes::Type.coerce(options[:of], value) }
+      private
+
+      def item_klass(klass)
+        return klass unless klass.is_a? ::String
+        Object.const_get(klass)
       end
     end
   end

--- a/test/array_type_test.rb
+++ b/test/array_type_test.rb
@@ -32,6 +32,7 @@ describe ShallowAttributes::Type::Array do
         type.coerce([], of: Integer).must_equal []
         type.coerce(['1', '2'], of: Integer).must_equal [1, 2]
         type.coerce([true, false], of: Integer).must_equal [1, 0]
+        type.coerce(['1', '2'], of: 'Integer').must_equal [1, 2]
       end
     end
   end


### PR DESCRIPTION
Hello.
I would like to use ActiveRecord models as Array values. But when class name puts into string, class name includes all model fields and I get something strange errors with missing constants.