### PR TITLE
Mass-assignment can work with a stringified hash

### DIFF
--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -86,7 +86,9 @@ module ShallowAttributes
     #
     # @since 0.1.0
     def attributes=(attributes)
-      @attributes.merge!(attributes)
+      attributes.each_pair do |key, value|
+        @attributes[key.to_sym] = value
+      end
       define_attributes
     end
 

--- a/test/shallow_attributes_test.rb
+++ b/test/shallow_attributes_test.rb
@@ -100,18 +100,26 @@ describe ShallowAttributes do
   end
 
   describe '#attributes=' do
-    it 'mass-assignments from symbolized hash' do
+    it 'mass-assigns attributes from symbolized hash' do
       user.attributes = { name: 'Alex' }
 
       user.name.must_equal 'Alex'
       user.age.must_equal 22
     end
 
-    it 'mass-assignments from stringified hash' do
+    it 'mass-assigns attributes from stringified hash' do
       user.attributes = { 'name' => 'Alex' }
 
       user.name.must_equal 'Alex'
       user.age.must_equal 22
+    end
+
+    it 'mass-assigns uninitialized attributes from stringified hash' do
+      user = MainUser.new
+      user.age.must_be_nil
+
+      user.attributes = {"age" => "21"}
+      user.age.must_equal 21
     end
   end
 


### PR DESCRIPTION
Hello,

We came across an issue where mass assigning a stringified hash of attributes would raise a `KeyError` if any of those attributes were uninitialized on the object that mixes in `ShallowAttributes`.

Example:

``` ruby
class MainUser
  include ShallowAttributes
  attributes :age, Integer
end

u = MainUser.new
u.attributes # {}
u.attributes = {"age" => 21} # => KeyError
```

And this is the type of error you would get:

```
ShallowAttributes::#attributes=#test_0003_sets attributes which have not been initialized:
RuntimeError: can't add a new key into hash during iteration
    /shallow_attributes/lib/shallow_attributes/class_methods.rb:105:in `age='
    /shallow_attributes/lib/shallow_attributes/instance_methods.rb:207:in `block in define_attributes'
    /shallow_attributes/lib/shallow_attributes/instance_methods.rb:206:in `each'
    /shallow_attributes/lib/shallow_attributes/instance_methods.rb:206:in `define_attributes'
    /shallow_attributes/lib/shallow_attributes/instance_methods.rb:90:in `attributes='
    /shallow_attributes/test/shallow_attributes_test.rb:121:in `block (3 levels) in <top (required)>'
```

The reason we get this error is because of how we use ShallowAttributes with our form objects.

1. The form object is built in a `before_action` and then we update the form object with the POST data.
2. We perform mass assignment with a stringified hash (It's actually `ActionController::StrongParameters`) rather than a symbolized hash.

This patch changes the behaviour to make mass assignment work with both stringified and symbolized hashes. Given `to_sym` on symbols is a no-op there should be minimal overhead to projects using symbolized hashes.

Happy to have any feedback :smile:

Cheers,
Tate