### PR TITLE
Feature/present option for attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ page.reset_attribute(:views)  # => 0
 page.views                    # => 0
 ```
 
+### Mandatory attributes
+You can provide `present: true` option for any attribute that will prevent class from initialization
+if this attribute was not provided:
+
+``` ruby
+class CreditCard
+  include ShallowAttributes
+  attribute :number, Integer, present: true
+  attribute :owner, String, present: true
+end
+
+card = CreditCard.new(number: 1239342)
+# => ShallowAttributes::MissingAttributeError: Mandatory attribute "owner" was not provided
+```
+
+
 ### Embedded Value
 
 ``` ruby

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Or install it yourself as:
 
 * [Using ShallowAttributes with Classes](#using-shallowattributes-with-classes)
 * [Default Values](#default-values)
+* [Mandatory Attributes](#mandatory-attributes)
 * [Embedded Value](#embedded-value)
 * [Custom Coercions](#custom-coercions)
 * [Collection Member Coercions](#collection-member-coercions)

--- a/lib/shallow_attributes.rb
+++ b/lib/shallow_attributes.rb
@@ -20,7 +20,7 @@ module ShallowAttributes
   #
   # @param [Class] base the class containing class methods
   #
-  # @return [Class] class for incluting ShallowAttributes gem
+  # @return [Class] class for including ShallowAttributes gem
   #
   # @since 0.1.0
   def self.included(base)

--- a/lib/shallow_attributes.rb
+++ b/lib/shallow_attributes.rb
@@ -9,6 +9,11 @@ require 'shallow_attributes/version'
 module ShallowAttributes
   include InstanceMethods
 
+  # Error class for mandatory arguments that were not provided
+  #
+  # @since 0.10.0
+  class MissingAttributeError < TypeError; end
+
   # Including ShallowAttributes class methods to specific class
   #
   # @private

--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -30,6 +30,18 @@ module ShallowAttributes
       @default_values ||= {}
     end
 
+    # Returns hash with mandatory attributes
+    #
+    # @private
+    #
+    # @return [Hash] hash with mandatory attributes
+    #
+    # @since 0.10.0
+
+    def mandatory_attributes
+      @mandatory_attributes ||= {}
+    end
+
     # Returns all class attributes.
     #
     # @example Create new User instance
@@ -75,6 +87,7 @@ module ShallowAttributes
       options[:default] ||= [] if type == Array
 
       default_values[name] = options.delete(:default)
+      mandatory_attributes[name] = options.delete(:present)
 
       initialize_setter(name, type, options)
       initialize_getter(name)

--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -19,7 +19,7 @@ module ShallowAttributes
       end
     end
 
-    # Returns hash which contain default values for each attribute
+    # Returns hash that contains default values for each attribute
     #
     # @private
     #
@@ -30,14 +30,13 @@ module ShallowAttributes
       @default_values ||= {}
     end
 
-    # Returns hash with mandatory attributes
+    # Returns hash that contains mandatory attributes
     #
     # @private
     #
     # @return [Hash] hash with mandatory attributes
     #
     # @since 0.10.0
-
     def mandatory_attributes
       @mandatory_attributes ||= {}
     end
@@ -70,6 +69,7 @@ module ShallowAttributes
     # @option options [Object] :default default value for attribute
     # @option options [Class] :of class of array elems
     # @option options [boolean] :allow_nil cast `nil` to integer or float
+    # @option options [boolean] :present raise error if attribute was not provided
     #
     # @example Create new User instance
     #   class User
@@ -143,7 +143,7 @@ module ShallowAttributes
     #
     # @private
     #
-    # @param [Class] class of type
+    # @param [Class] type the class of type
     #
     # @return [Bool]
     #

--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -37,6 +37,7 @@ module ShallowAttributes
       end
       define_attributes
       define_default_attributes
+      define_mandatory_attributes
     end
 
     # Returns hash of object attributes
@@ -68,7 +69,7 @@ module ShallowAttributes
     # @since 0.1.0
     alias_method :to_hash, :attributes
 
-    # Mass-assignment attribut values
+    # Attribute values mass-assignment
     #
     # @param [Hash] attributes the attributes which will be assignment
     #
@@ -82,7 +83,7 @@ module ShallowAttributes
     #   user.attributes = { name: "Ben" }
     #   user.attributes # => { name: "Ben" }
     #
-    # @return [Hash] attibutes hash
+    # @return [Hash] attributes hash
     #
     # @since 0.1.0
     def attributes=(attributes)
@@ -92,14 +93,14 @@ module ShallowAttributes
       define_attributes
     end
 
-    # Reser specific attribute to defaul value.
+    # Reset specific attribute to default value.
     #
-    # @param [Symbol] attribute the attribute which will be resete
+    # @param [Symbol] attribute the attribute which will be reset
     #
-    # @example Reset name valus
+    # @example Reset name value
     #   class User
     #     include ShallowAttributes
-    #     attribute :name, String, defauil: 'Ben'
+    #     attribute :name, String, default: 'Ben'
     #   end
     #
     #   user = User.new(name: 'Anton')
@@ -183,7 +184,7 @@ module ShallowAttributes
 
   private
 
-    # Defene default value for attributes.
+    # Define default values for attributes.
     #
     # @private
     #
@@ -197,7 +198,23 @@ module ShallowAttributes
       end
     end
 
-    # Defene attributes from `@attributes` instance value.
+    # Define mandatory attributes for object and raise exception
+    # if they were not provided
+    #
+    # @private
+    #
+    # @return [nil]
+    #
+    # @since 0.10.0
+
+    def define_mandatory_attributes
+      mandatory_attributes.each do |key, value|
+        next unless @attributes[key].nil? && value
+        raise ShallowAttributes::MissingAttributeError, %(Mandatory attribute "#{key}" was not provided)
+      end
+    end
+
+    # Define attributes from `@attributes` instance value.
     #
     # @private
     #
@@ -241,6 +258,18 @@ module ShallowAttributes
     # @since 0.1.0
     def default_values
       @default_values ||= self.class.default_values
+    end
+
+    # Returns hash of mandatory class attributes
+    #
+    # @private
+    #
+    # @return [Hash]
+    #
+    # @since 0.10.0
+
+    def mandatory_attributes
+      @mandatory_attributes ||= self.class.mandatory_attributes
     end
   end
 end

--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -6,7 +6,7 @@ module ShallowAttributes
   #
   # @since 0.1.0
   module InstanceMethods
-    # Lambda object for gettring attributes hash for specific
+    # Lambda object for getting attributes hash for a specific
     # value object.
     #
     # @private
@@ -14,7 +14,7 @@ module ShallowAttributes
     # @since 0.1.0
     TO_H_PROC = ->(value) { value.respond_to?(:to_hash) ? value.to_hash : value }
 
-    # Initialize instance object with specific attributes
+    # Initialize an instance object with specific attributes
     #
     # @param [Hash] attrs the attributes contained in the class
     #
@@ -42,7 +42,7 @@ module ShallowAttributes
 
     # Returns hash of object attributes
     #
-    # @example Returns all user attributs
+    # @example Returns all user attributes
     #   class User
     #     include ShallowAttributes
     #     attribute :name, String
@@ -118,13 +118,13 @@ module ShallowAttributes
     #
     # @private
     #
-    # @param [Hash] values the new attributes for current object
-    # @param [Hash] options
+    # @param [Hash] value the new attributes for current object
+    # @param [Hash] _options
     #
     # @example Use embedded values
     #   class User
     #     include ShallowAttributes
-    #     attribute :name, String, defauil: 'Ben'
+    #     attribute :name, String, default: 'Ben'
     #   end
     #
     #   class Post
@@ -143,14 +143,14 @@ module ShallowAttributes
       self
     end
 
-    # Equalate two value objects
+    # Compare values of two objects
     #
     # @param [Object] object the other object
     #
-    # @example Equalate two value objects
+    # @example Compare two value objects
     #   class User
     #     include ShallowAttributes
-    #     attribute :name, String, defauil: 'Ben'
+    #     attribute :name, String, default: 'Ben'
     #   end
     #
     #   user1 = User.new(name: 'Anton')
@@ -166,10 +166,10 @@ module ShallowAttributes
 
     # Inspect instance object
     #
-    # @example Equalate two value objects
+    # @example Inspect the object
     #   class User
     #     include ShallowAttributes
-    #     attribute :name, String, defauil: 'Ben'
+    #     attribute :name, String, default: 'Ben'
     #   end
     #
     #   user = User.new(name: 'Anton')
@@ -182,7 +182,7 @@ module ShallowAttributes
       "#<#{self.class}#{attributes.map{ |k, v| " #{k}=#{v.inspect}" }.join}>"
     end
 
-  private
+    private
 
     # Define default values for attributes.
     #
@@ -203,10 +203,11 @@ module ShallowAttributes
     #
     # @private
     #
-    # @return [nil]
+    # @raise [MissingAttributeError] if attribute was not provided
+    #
+    # @return the object
     #
     # @since 0.10.0
-
     def define_mandatory_attributes
       mandatory_attributes.each do |key, value|
         next unless @attributes[key].nil? && value
@@ -227,13 +228,13 @@ module ShallowAttributes
       end
     end
 
-    # Retrns default value for specific attribute. Defaul values hash
-    # takes from class getter `default_values`.
+    # Returns default value for specific attribute. Default values hash
+    # is taken from class getter `default_values`.
     #
     # @private
     #
     # @return [nil] if default value not defined
-    # @return [Object] if default value defined
+    # @return [Object] if default value is defined
     #
     # @since 0.1.0
     def default_value_for(attribute)
@@ -267,7 +268,6 @@ module ShallowAttributes
     # @return [Hash]
     #
     # @since 0.10.0
-
     def mandatory_attributes
       @mandatory_attributes ||= self.class.mandatory_attributes
     end

--- a/lib/shallow_attributes/type.rb
+++ b/lib/shallow_attributes/type.rb
@@ -7,11 +7,11 @@ require 'shallow_attributes/type/string'
 require 'shallow_attributes/type/time'
 
 module ShallowAttributes
-  # Namespace for standart type classes
+  # Namespace for standard type classes
   #
   # @since 0.1.0
   module Type
-    # Error class for ivalid value types
+    # Error class for invalid value types
     #
     # @since 0.1.0
     class InvalidValueError < TypeError
@@ -37,7 +37,7 @@ module ShallowAttributes
       # @private
       #
       # @param [Class] type the type class object
-      # @param [Object] value the value that should be submit to the necessary type
+      # @param [Object] value the value that should be coerced to the necessary type
       # @param [Hash] options the options to create a message with.
       # @option options [String] :of The type of array
       # @option options [boolean] :allow_nil cast `nil` to integer or float
@@ -63,7 +63,7 @@ module ShallowAttributes
       #
       # @private
       #
-      # @param [Class] type the type class object
+      # @param [Class] klass the type class object
       #
       # @example Returns Sting type class
       #   ShallowAttributes::Type.instance_for(String)

--- a/lib/shallow_attributes/type/array.rb
+++ b/lib/shallow_attributes/type/array.rb
@@ -18,7 +18,7 @@ module ShallowAttributes
       #   ShallowAttributes::Type::Array.new.coerce([1, 2], String)
       #     # => ['1', '2']
       #
-      # @raise [InvalidValueError] if values is not Array
+      # @raise [InvalidValueError] if value is not an Array
       #
       # @return [Array]
       #

--- a/lib/shallow_attributes/type/boolean.rb
+++ b/lib/shallow_attributes/type/boolean.rb
@@ -25,7 +25,7 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] _options
       #
       # @example Convert integer to boolean value
       #   ShallowAttributes::Type::Boolean.new.coerce(1)
@@ -34,7 +34,7 @@ module ShallowAttributes
       #   ShallowAttributes::Type::Boolean.new.coerce(0)
       #     # => false
       #
-      # @raise [InvalidValueError] if values is not included in true and false arrays
+      # @raise [InvalidValueError] if value is not included in true and false arrays
       #
       # @return [boolean]
       #

--- a/lib/shallow_attributes/type/date_time.rb
+++ b/lib/shallow_attributes/type/date_time.rb
@@ -11,13 +11,13 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] _options
       #
       # @example Convert integer to datetime value
       #   ShallowAttributes::Type::DateTime.new.coerce('Thu Nov 29 14:33:20 GMT 2001')
       #     # => '2001-11-29T14:33:20+00:00'
       #
-      # @raise [InvalidValueError] if values is not a sting
+      # @raise [InvalidValueError] if value is not a string
       #
       # @return [DateTime]
       #

--- a/lib/shallow_attributes/type/float.rb
+++ b/lib/shallow_attributes/type/float.rb
@@ -1,6 +1,6 @@
 module ShallowAttributes
   module Type
-    # This class needs for cange object type to Float.
+    # This class is needed to change object type to Float.
     #
     # @abstract
     #
@@ -11,14 +11,14 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] options
       # @option options [boolean] :allow_nil cast `nil` to integer or float
       #
       # @example Convert string to float value
       #   ShallowAttributes::Type::Float.new.coerce('2001')
       #     # => 2001.0
       #
-      # @raise [InvalidValueError] if values is invalid
+      # @raise [InvalidValueError] if value is invalid
       #
       # @return [Float]
       #

--- a/lib/shallow_attributes/type/integer.rb
+++ b/lib/shallow_attributes/type/integer.rb
@@ -1,6 +1,6 @@
 module ShallowAttributes
   module Type
-    # This class cange object to Integer.
+    # This class changes object to Integer.
     #
     # @abstract
     #
@@ -11,14 +11,14 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] options
       # @option options [boolean] :allow_nil cast `nil` to integer or float
       #
       # @example Convert sting to integer value
       #   ShallowAttributes::Type::Integer.new.coerce('2001')
       #     # => 2001
       #
-      # @raise [InvalidValueError] if values is invalid
+      # @raise [InvalidValueError] if value is invalid
       #
       # @return [Integer]
       #

--- a/lib/shallow_attributes/type/string.rb
+++ b/lib/shallow_attributes/type/string.rb
@@ -11,9 +11,9 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] _options
       #
-      # @example Convert intger to string value
+      # @example Convert integer to string value
       #   ShallowAttributes::Type::String.new.coerce(2001)
       #     # => '2001'
       #

--- a/lib/shallow_attributes/type/time.rb
+++ b/lib/shallow_attributes/type/time.rb
@@ -11,13 +11,13 @@ module ShallowAttributes
       # @private
       #
       # @param [Object] value
-      # @param [Hash] option
+      # @param [Hash] _options
       #
       # @example Convert string to Time value
       #   ShallowAttributes::Type::Time.new.coerce('Thu Nov 29 14:33:20 GMT 2001')
       #     # => '2001-11-29 14:33:20 +0000'
       #
-      # @raise [InvalidValueError] if values is not a sting or integer
+      # @raise [InvalidValueError] if value is not a sting or an integer
       #
       # @return [Time]
       #

--- a/lib/shallow_attributes/version.rb
+++ b/lib/shallow_attributes/version.rb
@@ -2,5 +2,5 @@ module ShallowAttributes
   # Defines the full version
   #
   # @since 0.1.0
-  VERSION = "0.10.0".freeze
+  VERSION = "0.9.2".freeze
 end

--- a/lib/shallow_attributes/version.rb
+++ b/lib/shallow_attributes/version.rb
@@ -2,5 +2,5 @@ module ShallowAttributes
   # Defines the full version
   #
   # @since 0.1.0
-  VERSION = "0.9.2".freeze
+  VERSION = "0.10.0".freeze
 end

--- a/test/present_option_test.rb
+++ b/test/present_option_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class Book
+  include ShallowAttributes
+  attribute :title, String, present: true
+end
+
+class CreditCard
+  include ShallowAttributes
+  attribute :number, Integer, present: true
+  attribute :owner, String, present: true
+end
+
+class FridgeWithDefault
+  include ShallowAttributes
+  attribute :temperature, String, present: true, default: '+4C'
+end
+
+class UserWithPresentFalse
+  include ShallowAttributes
+  attribute :name, String, present: false
+end
+
+class TypeChecking
+  include ShallowAttributes
+  attribute :arr, Array, present: true
+  attribute :datetime, DateTime, present: true
+  attribute :float, Float, present: true
+  attribute :time, Time, present: true
+  attribute :bool, Boolean, present: true
+end
+
+describe 'when present option set to true' do
+  describe 'for one attribute' do
+    it 'raises error for missing attribute' do
+      err = -> { Book.new }.must_raise ShallowAttributes::MissingAttributeError
+      err.message.must_equal 'Mandatory attribute "title" was not provided'
+    end
+
+    it 'works fine for present attribute' do
+      Book.new(title: 'The Stranger').title.must_equal 'The Stranger'
+    end
+  end
+
+  describe 'for more than one attribute' do
+    it 'raises error for the first attribute' do
+      err = -> { CreditCard.new }.must_raise ShallowAttributes::MissingAttributeError
+      err.message.must_equal 'Mandatory attribute "number" was not provided'
+    end
+
+    it 'works fine for present attributes' do
+      CreditCard.new(number: 123, owner: 'Andrew').number.must_equal 123
+    end
+  end
+
+  describe 'for an attribute with a default value' do
+    # I don't know for what reason someone would set presence & default options
+    # together, but just in case
+
+    it 'sets missing attribute to default value' do
+      FridgeWithDefault.new.temperature.must_equal '+4C'
+    end
+  end
+
+  describe 'for various types' do
+    let(:options) { Hash[datetime: DateTime.now, float: 0.10, time: DateTime.now, bool: true] }
+
+    it 'sets default array value to [], so nothing is raised' do
+      TypeChecking.new(options).arr.must_equal []
+    end
+
+    it 'raises error if DateTime is not present' do
+      -> { TypeChecking.new(options.tap { |opts| opts.delete(:datetime) }) }
+        .must_raise ShallowAttributes::MissingAttributeError
+    end
+
+    it 'raises error if Float is not present' do
+      -> { TypeChecking.new(options.tap { |opts| opts.delete(:float) }) }
+        .must_raise ShallowAttributes::MissingAttributeError
+    end
+
+    it 'raises error if Time is not present' do
+      -> { TypeChecking.new(options.tap { |opts| opts.delete(:time) }) }
+        .must_raise ShallowAttributes::MissingAttributeError
+    end
+
+    it 'raises error if Boolean is not present' do
+      -> { TypeChecking.new(options.tap { |opts| opts.delete(:bool) }) }
+        .must_raise ShallowAttributes::MissingAttributeError
+    end
+  end
+end
+
+describe 'with present option set to false' do
+  # Again, I doubt that anyone would ever specify 'present: false', but just in case
+  it 'does not raise error' do
+    UserWithPresentFalse.new(name: 'Nikita').name.must_equal 'Nikita'
+  end
+end


### PR DESCRIPTION
Hi!
Firstly, thank you for this gem, i find it really great and would like to contribute my work to it.

I've implemented `present:` option that is mentioned in #4

So now one can specify, for example:
``` ruby
attribute :name, String, present: true
```
And error will be raised if this attribute is not provided.

Also i've improved some typos in documentation and have bumped version if you don't mind  :)

Please let me know what do you think of these changes.

Have a great day!