### PR TITLE
Default values can be derived from private methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ class Page
   # default from a method name as symbol
   attribute :editor_title, String,  default: :default_editor_title
 
+  private
+
   def default_editor_title
     published ? title : "UNPUBLISHED: #{title}"
   end

--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -244,7 +244,7 @@ module ShallowAttributes
       when Proc
         value.call(self, attribute)
       when Symbol, String
-        self.class.method_defined?(value) ? send(value) : value
+        respond_to?(value, true) ? send(value) : value
       else
         value
       end

--- a/test/shallow_attributes_test.rb
+++ b/test/shallow_attributes_test.rb
@@ -13,6 +13,7 @@ class MainUser
   attribute :full_name, String, default: -> (user, attribute) { "#{user.name} #{user.last_name}" }
   attribute :age, Integer
   attribute :birthday, DateTime
+  attribute :color, String, default: :default_color
 
   attribute :friends_count, Integer, default: 0
   attribute :sizes, Array, of: Integer
@@ -22,6 +23,12 @@ class MainUser
   def default_last_name
     'Affleck'
   end
+
+  private
+
+  def default_color
+    'Pink'
+  end
 end
 
 describe ShallowAttributes do
@@ -29,7 +36,7 @@ describe ShallowAttributes do
 
   describe '::attributes' do
     it 'returns class attributes array' do
-      MainUser.attributes.must_equal(%i(name last_name full_name age birthday friends_count sizes admin))
+      MainUser.attributes.must_equal(%i(name last_name full_name age birthday color friends_count sizes admin))
     end
   end
 
@@ -125,7 +132,7 @@ describe ShallowAttributes do
 
   describe '#attributes' do
     it 'returns attributes like hash' do
-      user.attributes.must_equal(name: 'Anton', age: 22, last_name: "Affleck", full_name: "Anton Affleck", friends_count: 0, sizes: [], admin: false)
+      user.attributes.must_equal(name: 'Anton', age: 22, last_name: "Affleck", full_name: "Anton Affleck", color: "Pink", friends_count: 0, sizes: [], admin: false)
     end
 
     describe 'when value is nil' do
@@ -133,7 +140,7 @@ describe ShallowAttributes do
         user.name  = nil
         user.age   = nil
         user.admin = nil
-        user.attributes.must_equal(name: '', age: nil, last_name: "Affleck", full_name: "Anton Affleck", friends_count: 0, sizes: [], admin: false)
+        user.attributes.must_equal(name: '', age: nil, last_name: "Affleck", full_name: "Anton Affleck", color: "Pink", friends_count: 0, sizes: [], admin: false)
       end
     end
   end


### PR DESCRIPTION
Hello there,

This patch makes it so default values can be derived by private methods as well continuing to support public methods.

In our usage of ShallowAttributes we'd prefer to keep default values as private methods since they have no purpose beyond initailization. We have found you can still test these methods indirectly by testing initialization.

All feedback welcome.

Cheers,
Tate