### PR TITLE
require 'date' for Type::DateTime

### DIFF
--- a/lib/shallow_attributes/type/date_time.rb
+++ b/lib/shallow_attributes/type/date_time.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module ShallowAttributes
   module Type
     # Abstract class for typecast object to DateTime type.


### PR DESCRIPTION
DateTime is part of Std-lib and needs to be required