### PR TITLE
Fix bug for Custom Types when the type changes to Hash after call the `attributes` method

### DIFF
--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -58,7 +58,7 @@ module ShallowAttributes
       hash = {}
       @attributes.map do |key, value|
         hash[key] =
-          value.is_a?(Array) ? value.map!(&TO_H_PROC) : TO_H_PROC.call(value)
+          value.is_a?(Array) ? value.map(&TO_H_PROC) : TO_H_PROC.call(value)
       end
       hash
     end

--- a/test/custom_types_test.rb
+++ b/test/custom_types_test.rb
@@ -25,30 +25,36 @@ end
 
 describe ShallowAttributes do
   describe 'with custom types' do
-    it 'allows embedded values' do
-      person = Person.new(address: {
+    let(:person) do
+      Person.new(address: {
         street: 'Street 1/2', city: {
           name: 'NYC'
         }
       })
+    end
 
-      person.address.zipcode.must_equal "111111"
-      person.address.street.must_equal "Street 1/2"
+    it 'allows embedded values' do
+      person.address.zipcode.must_equal '111111'
+      person.address.street.must_equal 'Street 1/2'
       person.address.city.size.must_equal 9000
-      person.address.city.name.must_equal "NYC"
+      person.address.city.name.must_equal 'NYC'
     end
 
     it 'returns normal hash' do
-      person = Person.new(address: {
-        street: 'Street 1/2', city: {
-          name: 'NYC'
-        }
-      })
-
-      person.address.zipcode.must_equal "111111"
-      person.address.street.must_equal "Street 1/2"
+      person.address.zipcode.must_equal '111111'
+      person.address.street.must_equal 'Street 1/2'
       person.address.city.size.must_equal 9000
-      person.address.city.name.must_equal "NYC"
+      person.address.city.name.must_equal 'NYC'
+    end
+
+    it 'builds the custom types with the correct class' do
+      person.address.must_be_instance_of Address
+      person.address.city.must_be_instance_of City
+    end
+
+    it 'does not change the attribute type after call the method #attributes' do
+      person.attributes
+      person.address.must_be_instance_of Address
     end
 
     describe 'when one of attribute is array' do
@@ -87,6 +93,16 @@ describe ShallowAttributes do
 
         person.addresses[1].city.name = 'Spb'
         person.addresses[1].city.name.must_equal 'Spb'
+      end
+
+      it 'builds the custom types with the correct class' do
+        person.addresses[0].must_be_instance_of Address
+        person.addresses[0].city.must_be_instance_of City
+      end
+
+      it 'does not change the attribute type after call the method #attributes' do
+        person.attributes
+        person.addresses[0].must_be_instance_of Address
       end
 
       describe '#attributes' do

--- a/test/dry_types_test.rb
+++ b/test/dry_types_test.rb
@@ -13,7 +13,7 @@ class MainDryUser
   include ShallowAttributes
 
   attribute :name, Types::Coercible::String
-  attribute :age, Types::Coercible::Int
+  attribute :age, Types::Coercible::Integer
   attribute :birthday, DateTime
 end
 


### PR DESCRIPTION
Greetings!

I figured out a bug that changes the custom type after the method `attributes` is called from the model.

Remember these classes...

```ruby
class Address
  include ShallowAttributes
  attribute :street, String
end

class Person
  include ShallowAttributes
  attribute :address, Address
end
```

Current behavior:
```ruby
person = Person.new(address: { street: 'Street 1/2' })
person.address.class
# => Address
person.address
# => #<Address street="Street 1/2">
person.attributes
# => { address: { street: "Street 1/2" } }
person.address.class
# => Hash
person.address
# => { street: "Street 1/2" }
```

After fix behavior:

```ruby
person = Person.new(address: { street: 'Street 1/2' })
person.address.class
# => Address
person.address
# => #<Address street="Street 1/2">
person.attributes
# => { address: { street: "Street 1/2" } }
person.address.class
# => Address
person.address
# => #<Address street="Street 1/2">
```

I think this is the expected behavior 😄 
Any comments about the changes and/or code implementation are welcome