### PR TITLE
fix coercion of ShallowAttributes values

### DIFF
--- a/lib/shallow_attributes/instance_methods.rb
+++ b/lib/shallow_attributes/instance_methods.rb
@@ -139,7 +139,13 @@ module ShallowAttributes
     #
     # @since 0.1.0
     def coerce(value, _options = {})
-      self.attributes = value
+      self.attributes =
+        if value.class.included_modules.include?(ShallowAttributes)
+          value.to_h
+        else
+          value
+        end
+
       self
     end
 

--- a/lib/shallow_attributes/type/string.rb
+++ b/lib/shallow_attributes/type/string.rb
@@ -20,7 +20,7 @@ module ShallowAttributes
       # @return [Sting]
       #
       # @since 0.1.0
-      def coerce(value, _options = {})
+      def coerce(value, options = {})
         case value
         when nil then options[:allow_nil] ? nil : ''
         when ::Array then value.join

--- a/shallow_attributes.gemspec
+++ b/shallow_attributes.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "dry-types", "~> 0.11"

--- a/test/custom_types_test.rb
+++ b/test/custom_types_test.rb
@@ -58,23 +58,22 @@ describe ShallowAttributes do
     end
 
     describe 'when one of attribute is array' do
-      let(:person) do
-        Person.new(
-          addresses: [
-            {
-              street: 'Street 1/2',
-              city: {
-                name: 'NYC'
-              }
-            },
-            {
-              street: 'Street 3/2',
-              city: {
-                name: 'Moscow'
-              }
-            }
-          ]
-        )
+      let(:person) { Person.new addresses: [address_1, address_2] }
+      let(:address_1) do
+        {
+          street: 'Street 1/2',
+          city: {
+            name: 'NYC'
+          }
+        }
+      end
+      let(:address_2) do
+        {
+          street: 'Street 3/2',
+          city: {
+            name: 'Moscow'
+          }
+        }
       end
 
       it 'allows embedded values' do
@@ -103,6 +102,35 @@ describe ShallowAttributes do
       it 'does not change the attribute type after call the method #attributes' do
         person.attributes
         person.addresses[0].must_be_instance_of Address
+      end
+
+      describe 'array of ShallowAttributes objects' do
+        let(:address_1) do
+          Address.new(
+            street: 'Street 1/2',
+            city: {
+              name: 'NYC'
+            }
+          )
+        end
+        let(:address_2) do
+          Address.new(
+            street: 'Street 3/2',
+            city: {
+              name: 'Moscow'
+            }
+          )
+        end
+
+        it 'allows embedded ShallowAttributes objects' do
+          person.addresses.count.must_equal 2
+
+          person.addresses[0].street.must_equal 'Street 1/2'
+          person.addresses[0].city.name.must_equal 'NYC'
+
+          person.addresses[1].street.must_equal 'Street 3/2'
+          person.addresses[1].city.name.must_equal 'Moscow'
+        end
       end
 
       describe '#attributes' do


### PR DESCRIPTION
This PR fixes such cases:

```ruby
class A
  include ShallowAttributes
  attribute :a, Integer
end

class B
  include ShallowAttributes
  attribute :b, Array, of: A
end
  
a = A.new(a: 1)
b = B.new(b: [a])
```

```
NoMethodError: undefined method `each_pair' for #<A a=1>
from /Users/morr/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/shallow_attributes-0.9.4/lib/shallow_attributes/instance_methods.rb:90:in `attributes='
```