### PR TITLE
allow_nil for strings and inverse logic of allow_nil

### DIFF
--- a/lib/shallow_attributes/type/float.rb
+++ b/lib/shallow_attributes/type/float.rb
@@ -25,7 +25,7 @@ module ShallowAttributes
       # @since 0.1.0
       def coerce(value, options = {})
         case value
-        when nil then options[:allow_nil] ? 0.0 : nil
+        when nil then options[:allow_nil] ? nil : 0.0
         when ::TrueClass then 1.0
         when ::FalseClass then 0.0
         else

--- a/lib/shallow_attributes/type/integer.rb
+++ b/lib/shallow_attributes/type/integer.rb
@@ -25,7 +25,7 @@ module ShallowAttributes
       # @since 0.1.0
       def coerce(value, options = {})
         case value
-        when nil then options[:allow_nil] ? 0 : nil
+        when nil then options[:allow_nil] ? nil : 0
         when ::TrueClass then 1
         when ::FalseClass then 0
         else

--- a/lib/shallow_attributes/type/string.rb
+++ b/lib/shallow_attributes/type/string.rb
@@ -20,7 +20,7 @@ module ShallowAttributes
       # @return [Sting]
       #
       # @since 0.1.0
-      def coerce(value, _options = {})
+      def coerce(value, options = {})
         case value
         when nil then options[:allow_nil] ? nil : ''
         when ::Array then value.join

--- a/lib/shallow_attributes/type/string.rb
+++ b/lib/shallow_attributes/type/string.rb
@@ -22,7 +22,7 @@ module ShallowAttributes
       # @since 0.1.0
       def coerce(value, _options = {})
         case value
-        when nil then options[:allow_nil] ? '' : nil
+        when nil then options[:allow_nil] ? nil : ''
         when ::Array then value.join
         when ::Hash, ::Class then error(value)
         else

--- a/lib/shallow_attributes/type/string.rb
+++ b/lib/shallow_attributes/type/string.rb
@@ -22,6 +22,7 @@ module ShallowAttributes
       # @since 0.1.0
       def coerce(value, _options = {})
         case value
+        when nil then options[:allow_nil] ? '' : nil
         when ::Array then value.join
         when ::Hash, ::Class then error(value)
         else

--- a/test/float_type_test.rb
+++ b/test/float_type_test.rb
@@ -21,13 +21,13 @@ describe ShallowAttributes::Type::Float do
 
     describe 'when value is Nil' do
       it 'returns nil' do
-        assert_nil type.coerce(nil)
+        type.coerce(nil).must_equal 0
       end
     end
 
     describe 'when allow_nil is true' do
       it 'returns float' do
-        type.coerce(nil, allow_nil: true).must_equal 0.0
+        assert_nil type.coerce(nil, allow_nil: true)
       end
     end
 

--- a/test/integer_type_test.rb
+++ b/test/integer_type_test.rb
@@ -20,13 +20,13 @@ describe ShallowAttributes::Type::Integer do
 
     describe 'when value is Nil' do
       it 'returns nil' do
-        assert_nil type.coerce(nil)
+        type.coerce(nil).must_equal 0
       end
     end
 
     describe 'when allow_nil is true' do
       it 'returns integer' do
-        type.coerce(nil, allow_nil: true).must_equal 0
+        assert_nil type.coerce(nil, allow_nil: true)
       end
     end
 

--- a/test/shallow_attributes_test.rb
+++ b/test/shallow_attributes_test.rb
@@ -140,7 +140,7 @@ describe ShallowAttributes do
         user.name  = nil
         user.age   = nil
         user.admin = nil
-        user.attributes.must_equal(name: '', age: nil, last_name: "Affleck", full_name: "Anton Affleck", color: "Pink", friends_count: 0, sizes: [], admin: false)
+        user.attributes.must_equal(name: '', age: 0, last_name: "Affleck", full_name: "Anton Affleck", color: "Pink", friends_count: 0, sizes: [], admin: false)
       end
     end
   end

--- a/test/string_type_test.rb
+++ b/test/string_type_test.rb
@@ -30,6 +30,12 @@ describe ShallowAttributes::Type::String do
       end
     end
 
+    describe 'when allow_nil is true' do
+      it 'returns integer' do
+        type.coerce(nil, allow_nil: true).must_equal ''
+      end
+    end
+
     describe 'when value is TrueClass' do
       it 'returns string' do
         type.coerce(true).must_equal 'true'

--- a/test/string_type_test.rb
+++ b/test/string_type_test.rb
@@ -32,7 +32,7 @@ describe ShallowAttributes::Type::String do
 
     describe 'when allow_nil is true' do
       it 'returns integer' do
-        type.coerce(nil, allow_nil: true).must_equal ''
+        assert_nil type.coerce(nil, allow_nil: true)
       end
     end
 


### PR DESCRIPTION
1. I added `allow_nil` option to `String` type so it works similar to numeric types. Because there is no reason why you should forbid nil values in string fields.

2. Inverted logic of `allow_nil` because when you have such class
```ruby
class A
  include ShallowAttributes
  attribute :a, Integer, allow_nil: true
end
```

and you initializing `a` with `nil`
```ruby
A.new(a: nil)
```

you expect it's value to be `nil`, cause you specifically wrote `allow_nil: true` in class definition.
But currently it has `0` value.
```
pry(main)> A.new(a: nil).a
0
```