### PR TITLE
Fix coercion for embedded shallow attributes type, receiving unexpected parameters

### DIFF
--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -14,16 +14,16 @@ module ShallowAttributes
     #
     def inherited(subclass)
       super
-      if respond_to?(:default_values)
-        subclass.default_values.merge!(default_values)
-      end
-
       if respond_to?(:descriptions)
         subclass.descriptions.merge!(descriptions)
       end
 
       if respond_to?(:formats)
         subclass.formats.merge!(formats)
+      end
+
+      if respond_to?(:default_values)
+        subclass.default_values.merge!(default_values)
       end
     end
 

--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -17,6 +17,14 @@ module ShallowAttributes
       if respond_to?(:default_values)
         subclass.default_values.merge!(default_values)
       end
+
+      if respond_to?(:descriptions)
+        subclass.default_values.merge!(default_values)
+      end
+
+      if respond_to?(:formats)
+        subclass.default_values.merge!(default_values)
+      end
     end
 
     # Returns hash that contains default values for each attribute

--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -41,6 +41,14 @@ module ShallowAttributes
       @mandatory_attributes ||= {}
     end
 
+    def descriptions
+      @descriptions ||= {}
+    end
+
+    def formats
+      @formats ||= {}
+    end
+
     # Returns all class attributes.
     #
     # @example Create new User instance
@@ -88,6 +96,8 @@ module ShallowAttributes
 
       default_values[name] = options.delete(:default)
       mandatory_attributes[name] = options.delete(:present)
+      descriptions[name] = options.delete(:desc)
+      formats[name] = options.delete(:format)
 
       initialize_setter(name, type, options)
       initialize_getter(name)

--- a/lib/shallow_attributes/class_methods.rb
+++ b/lib/shallow_attributes/class_methods.rb
@@ -19,11 +19,11 @@ module ShallowAttributes
       end
 
       if respond_to?(:descriptions)
-        subclass.default_values.merge!(default_values)
+        subclass.descriptions.merge!(descriptions)
       end
 
       if respond_to?(:formats)
-        subclass.default_values.merge!(default_values)
+        subclass.formats.merge!(formats)
       end
     end
 

--- a/test/custom_types_test.rb
+++ b/test/custom_types_test.rb
@@ -152,5 +152,28 @@ describe ShallowAttributes do
         end
       end
     end
+    describe 'when custom type receives parameters not considered as attributes' do
+      let(:person) do
+        Person.new(
+            name: 'John',
+            address: {
+                street: 'Street',
+                number: '12'
+            }
+        )
+      end
+
+      it 'ignores the non existence parameter' do
+        hash = person.attributes
+        hash.must_equal({
+            name: 'John',
+            addresses: [],
+            address: {
+                street: 'Street',
+                zipcode: '111111'
+            }
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
## PROBLEM

Having two classes related like follow:

```ruby
class Address
  include ShallowAttributes

  attribute :street,  String
end

class Person
  include ShallowAttributes

  attribute :name,      String
  attribute :address,   Address
end
```

... when the embedded class receives parameters that doesn't match the defined attributes:

```ruby
{
    name: 'John',
        address: {
            street: 'Street',
            number: '12'
        }
}
```

... an error raises because doesn't find the definition in the class.

When a class including `ShallowAttribues` is initialized, during the initialization parameters non matching attributes are dismissed. But it doesn't happen during the lower levels in the hierarchy, because the objects are creating according to the type.  

## SOLUTION
Adding some logic during the `type` coercion and initialization avoid the conflict. 
